### PR TITLE
Attributes from -core-oscore-edhoc

### DIFF
--- a/draft-bormann-core-target-attr.md
+++ b/draft-bormann-core-target-attr.md
@@ -162,6 +162,15 @@ Initial entries in this sub-registry are as listed in {{pre-reg}}:
 | ecdh_key_crv    | The curve of the used ECDH keys                                                                            | IESG              | {{Section 2.1 of ?I-D.tiloca-core-oscore-discovery}} |
 | det_hash_alg    | The hash algorithm to use for computing deterministic requests                                             | IESG              | {{Section 2.1 of ?I-D.tiloca-core-oscore-discovery}} |
 | rekeying_scheme | The rekeying scheme used to distribute new keying material                                                 | IESG              | {{Section 2.1 of ?I-D.tiloca-core-oscore-discovery}} |
+| method          | A supported authentication method for EDHOC                                                                | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| csuite          | A supported cipher suite for EDHOC                                                                         | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| cred_t          | A supported type of authentication credential for EDHOC                                                    | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| idcred_t        | A supported type of authentication credential identifier for EDHOC                                         | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| ead_1           | A supported EDHOC EAD_1 item                                                                               | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| ead_2           | A supported EDHOC EAD_2 item                                                                               | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| ead_3           | A supported EDHOC EAD_3 item                                                                               | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| ead_4           | A supported EDHOC EAD_4 item                                                                               | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
+| comb_req        | Hint: support for the EDHOC+OSCORE request                                                                 | IESG              | {{Section 6 of ?I-D.ietf-core-oscore-edhoc}}         |
 {: #pre-reg title="Initial Entries in the Target Attributes Registry"}
 
 A number of names are reserved as they are used for parameters in


### PR DESCRIPTION
Added attributes from https://datatracker.ietf.org/doc/html/draft-ietf-core-oscore-edhoc-05#section-6

Noted while working on this PR:

- Since these attributes are specific to EDHOC, they would better start with a related prefix, e.g., "edhoc_".
   
- Also due to an added prefix as above, we may want to shorten the name of some attribute.